### PR TITLE
DPR2-2606 updated schema definition

### DIFF
--- a/schema/data-product-definition-schema.json
+++ b/schema/data-product-definition-schema.json
@@ -75,7 +75,10 @@
               "type": "string"
             },
             {
-              "$ref": "#/definitions/multiphaseQuery"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/multiphaseQuery"
+              }
             }
           ]
         },

--- a/schema/data-product-definition-schema.json
+++ b/schema/data-product-definition-schema.json
@@ -69,7 +69,16 @@
           "type": "array",
           "items": { "$ref": "#/definitions/dataset-parameter" }
         },
-        "query": { "type": "string" },
+        "query": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/multiphaseQuery"
+            }
+          ]
+        },
         "schema": {
           "type": "object",
           "required": ["field"],
@@ -543,6 +552,19 @@
       "properties": {
         "reportId": { "type": "string" },
         "joinField": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "multiphaseQuery": {
+      "type": "object",
+      "required": ["index", "datasource", "query"],
+      "properties": {
+        "index": { "type": "integer" },
+        "datasource": { "type": "string" },
+        "query": { "type": "string" },
+        "parameters": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/dataset-parameter" }
+        }
       }
     }
   }


### PR DESCRIPTION
Updated DPD JSON schema definition to take into account the refactored schema in which query accepts both a string and a list of MultiphaseQuery objects.